### PR TITLE
Don't error when the file size is too large, just skip

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,22 +13,6 @@ var pngquant = require('pngquant-bin').path;
 
 module.exports = function (opts) {
 	opts = opts || {};
-	
-	var errorCodes = {
-		SUCCESS : 0,
-		MISSING_ARGUMENT : 1,
-		READ_ERROR : 2,
-		INVALID_ARGUMENT : 4,
-		NOT_OVERWRITING_ERROR : 15,
-		CANT_WRITE_ERROR : 16,
-		OUT_OF_MEMORY_ERROR : 17,
-		WRONG_ARCHITECTURE : 18, // Missing SSE
-		PNG_OUT_OF_MEMORY_ERROR : 24,
-		LIBPNG_FATAL_ERROR : 25,
-		LIBPNG_INIT_ERROR : 35,
-		TOO_LARGE_FILE : 98,
-		TOO_LOW_QUALITY : 99
-	};
 
 	return function (file, imagemin, cb) {
 		if (!isPng(file.contents)) {
@@ -67,7 +51,12 @@ module.exports = function (opts) {
 			.use(pngquant, args.concat(['-f', '-o', exec.dest(), exec.src()]))
 			.run(file.contents, function (err, buf) {
 				if (err) {
-					cb(errorCodes.TOO_LARGE_FILE ? null : err);
+					if (err.code === 98) {
+						cb(null, file);
+						return
+					}
+
+					cb(err);
 					return;
 				}
 


### PR DESCRIPTION
This is to fix issue #6. If the error code response from pngquant is for the file being too large, ignore it and carry on execution.
