### PR TITLE
remove the callback on stderr.on('data')

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = function (opts) {
 
 		var args = ['-'];
 		var ret = [];
+		var err = '';
 		var len = 0;
 
 		if (opts.floyd && typeof opts.floyd === 'number') {
@@ -73,7 +74,14 @@ module.exports = function (opts) {
 			return;
 		});
 
-		cp.on('close', function () {
+		cp.on('close', function (code) {
+			if (code) {
+				err = new Error(err);
+				err.fileName = file.path;
+				cb(err);
+				return;
+			}
+			
 			if (len < file.contents.length) {
 				file.contents = Buffer.concat(ret, len);
 			}

--- a/index.js
+++ b/index.js
@@ -59,10 +59,7 @@ module.exports = function (opts) {
 
 		cp.stderr.setEncoding('utf8');
 		cp.stderr.on('data', function (data) {
-			var err = new Error(data);
-			err.fileName = file.path;
-			cb(err);
-			return;
+			err += data;
 		});
 
 		cp.stdout.on('data', function (data) {

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = function (opts) {
 				cb(err);
 				return;
 			}
-			
+
 			if (len < file.contents.length) {
 				file.contents = Buffer.concat(ret, len);
 			}


### PR DESCRIPTION
Remove the callback on `cp.stderr.on('data')`. In a special case, it called the callback several times. 

In other imagemin plugins, the cp.stderr.on(data) concat the err object with data. The callback is not called.