### PR TITLE
Version bump for last PRs to be propagated to NPM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imagemin-pngquant",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "pngquant imagemin plugin",
   "license": "MIT",
   "repository": "imagemin/imagemin-pngquant",


### PR DESCRIPTION
Currently, already compressed images break the build. Fixed by a PR merged in January, but never bumped the version. This should do the trick!