### PR TITLE
Add `strip` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = opts => input => {
 		args.push('--verbose');
 	}
 
-  if (opts.strip) {
+	if (opts.strip) {
 		args.push('--strip');
 	}
 

--- a/index.js
+++ b/index.js
@@ -47,6 +47,10 @@ module.exports = opts => input => {
 		args.push('--verbose');
 	}
 
+  if (opts.strip) {
+		args.push('--strip');
+	}
+
 	const cp = execa(pngquant, args, {
 		encoding: null,
 		input

--- a/readme.md
+++ b/readme.md
@@ -79,9 +79,9 @@ Print verbose status messages.
 ##### strip
 
 Type: `boolean`<br>
-Default: `false`
+Default: `false` (`true` on macOS)
 
-Remove optional metadata (dafault on Mac).
+Remove optional metadata.
 
 #### input
 

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,13 @@ Default: `false`
 
 Print verbose status messages.
 
+##### strip
+
+Type: `boolean`<br>
+Default: `false`
+
+Remove optional metadata (dafault on Mac).
+
 #### input
 
 Type: `Buffer` `Stream`


### PR DESCRIPTION
This is from pngquant --help:
pngquant, 2.10.1 (July 2017), by Kornel Lesinski, Greg Roelofs.
   Color profiles are supported via Little CMS. Using libpng 1.6.29.

usage:  pngquant [options] [ncolors] -- pngfile [pngfile ...]
        pngquant [options] [ncolors] - >stdout <stdin

options:
  --force           overwrite existing output files (synonym: -f)
  --skip-if-larger  only save converted files if they're smaller than original
  --output file     destination file path to use instead of --ext (synonym: -o)
  --ext new.png     set custom suffix/extension for output filenames
  --quality min-max don't save below min, use fewer colors below max (0-100)
  --speed N         speed/quality trade-off. 1=slow, 3=default, 11=fast & rough
  --nofs            disable Floyd-Steinberg dithering
  --posterize N     output lower-precision color (e.g. for ARGB4444 output)
  --strip           remove optional metadata (default on Mac)
  --verbose         print status messages (synonym: -v)

I created pull request to update windows version of pngquant in pngquant-bin and it wuld be greate to add this option in imagemin-pngquant.
