### PR TITLE
Don't throw on inputs larger than 10 MB

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ module.exports = (options = {}) => input => {
 
 	const cp = execa(pngquant, args, {
 		encoding: null,
+		maxBuffer: Infinity,
 		input
 	});
 


### PR DESCRIPTION
I'm using imagemin-pngquant with gulp-imagemin, and I encountered a problem when imagemin-pngquant processes many png files like this:

```
$ gulp imagemin
[12:25:08] Using gulpfile ~/Workspace/gulpfile.js
[12:25:08] Starting 'imagemin'...
[12:33:15] Plumber found unhandled error:
 Error in plugin 'gulp-imagemin'
Message:
    stdout maxBuffer exceeded
Details:
    stream: stdout
    fileName: /Users/kimiaki/Workspace/src/img/screen_shot/press_menu_PC.png
[12:43:06] gulp-imagemin: Minified 135 images (saved 45.3 MB - 64.4%)
[12:43:06] Finished 'imagemin' after 18 min
$
```
I looked into source and found index.js are using execa, [it sets default maxBuffer to 10MB](https://github.com/sindresorhus/execa#maxbuffer).

Then I looked imagemin-mozjpeg, [it sets Infinity to maxBuffer](https://github.com/imagemin/imagemin-mozjpeg/commit/722826f31c0a1b064da6e92749b3823ff66fff5c#diff-168726dbe96b3ce427e7fedce31bb0bcR82).

This pull request sets execa options same as imagemin-mozjpeg, to prevent maxBuffer exceeding.