### PR TITLE
Fix the default documented value for the `speed` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Type: `Object`
 ##### speed
 
 Type: `number`<br>
-Default: `3`<br>
+Default: `4`<br>
 Values: `1` (brute-force) to `11` (fastest)
 
 Speed `10` has 5% lower quality, but is about 8 times faster than the default. Speed `11` disables dithering and lowers compression level.


### PR DESCRIPTION
pngquant's default speed has changed to 4 instead of 3
https://github.com/kornelski/pngquant/blob/4219956d5e080be7905b5581314d913d20896934/rust/bin.rs#L61

It's [an old PR](https://github.com/gatsbyjs/gatsby/pull/9563) in the gatsby repo so I thought lets clean it up here as well.