### PR TITLE
Add 'ignoreCompressed' option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,13 @@ export interface Options {
 	@default false
 	*/
 	verbose?: boolean;
+
+	/**
+	 Prevent a PNG image from being compressed for a second time by calculating the bit depth.
+
+	 @default false
+	 */
+	ignoreCompressed?: boolean;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -16,6 +16,18 @@ const imageminPngquant = (options = {}) => input => {
 		return Promise.resolve(input);
 	}
 
+	if (options.ignoreCompressed === true) {
+		let bitsPerPixel = input[24] & 0xff;
+		if ((input[25] & 0xff) === 2) {
+			bitsPerPixel *= 3;
+		} else if ((input[25] & 0xff) === 6) {
+			bitsPerPixel *= 4;
+		}
+		if (bitsPerPixel === 8) {
+			return Promise.resolve(input);
+		}
+	}
+
 	const args = ['-'];
 
 	if (typeof options.speed !== 'undefined') {

--- a/readme.md
+++ b/readme.md
@@ -93,3 +93,10 @@ Print verbose status messages.
 Type: `Buffer | Stream`
 
 Buffer or stream to optimize.
+
+##### ignoreCompressed
+
+Type: `boolean`<br>
+Default: `false`
+
+Prevent a PNG image from being compressed for a second time by calculating the bit depth.


### PR DESCRIPTION
Add an alternative option to prevent a PNG image from being compressed for a second time by calculating the bit depth