### PR TITLE
Fix issue with `pngquant` and exit code 99

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,11 +63,8 @@ const imageminPngquant = (options = {}) => input => {
 	const promise = subprocess
 		.then(result => result.stdout) // eslint-disable-line promise/prefer-await-to-then
 		.catch(error => {
-			/*
-			We use `error.exitCode` to check for a special condition when running the pngquant binary. See details on handling of "99" code at https://pngquant.org (search for "status code 99").
-			
-			The `error.code` property will be undefined in many cases depending on timing issues for the subprocess invocation. The `error.exitCode` property contains the numeric process exit code. For all other cases, throw the error.
-			*/
+			// We use `error.exitCode` to check for a special condition when running the pngquant binary.
+			// See details on handling of "99" code at https://pngquant.org (search for "status code 99").
 			if (error.exitCode === 99) {
 				return input;
 			}

--- a/index.js
+++ b/index.js
@@ -63,7 +63,14 @@ const imageminPngquant = (options = {}) => input => {
 	const promise = subprocess
 		.then(result => result.stdout) // eslint-disable-line promise/prefer-await-to-then
 		.catch(error => {
-			if (error.code === 99) {
+			/*
+			 Use error.exitCode to check for special condition running pngquant bin - output should just be input
+			 See details on handling of "99" code at https://pngquant.org/ (search for "status code 99")
+			 The error.code will be undefined in many cases depending on timing issues for the subprocess invocation
+			 The error.exitCode contains the numeric process exit code.
+			 For all other cases, throw the error
+			 */
+			if (error.exitCode === 99) {
 				return input;
 			}
 

--- a/index.js
+++ b/index.js
@@ -64,12 +64,10 @@ const imageminPngquant = (options = {}) => input => {
 		.then(result => result.stdout) // eslint-disable-line promise/prefer-await-to-then
 		.catch(error => {
 			/*
-			 Use error.exitCode to check for special condition running pngquant bin - output should just be input
-			 See details on handling of "99" code at https://pngquant.org/ (search for "status code 99")
-			 The error.code will be undefined in many cases depending on timing issues for the subprocess invocation
-			 The error.exitCode contains the numeric process exit code.
-			 For all other cases, throw the error
-			 */
+			We use `error.exitCode` to check for a special condition when running the pngquant binary. See details on handling of "99" code at https://pngquant.org (search for "status code 99").
+			
+			The `error.code` property will be undefined in many cases depending on timing issues for the subprocess invocation. The `error.exitCode` property contains the numeric process exit code. For all other cases, throw the error.
+			*/
 			if (error.exitCode === 99) {
 				return input;
 			}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "imagemin-pngquant",
-	"version": "9.0.0",
+	"version": "9.0.1",
 	"description": "Imagemin plugin for `pngquant`",
 	"license": "MIT",
 	"repository": "imagemin/imagemin-pngquant",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "imagemin-pngquant",
-	"version": "9.0.1",
+	"version": "9.0.0",
 	"description": "Imagemin plugin for `pngquant`",
 	"license": "MIT",
 	"repository": "imagemin/imagemin-pngquant",


### PR DESCRIPTION
With recent updates to the image handling libraries in gatsby, routine image sharp operations started failing in builds.  Here is an example issue in gatsby: https://github.com/gatsbyjs/gatsby/issues/26723

Whenever a pngquant invocation cannot complete the requested transform (based on combination of the output and of the specified quality parameters), the binary returns a code of 99.  Perhaps because of unrelated updates in node.js packages, I found that the existing validation using the "error.code" element did not work.  Instead, the check should be performed on "error.exitCode".

This pull request makes a one line change (and adds comments - not sure if they follow the standards of the team but are provided for extra clarity).  Through additional instrumentation in index.js, I was able to determine that the "error.code" parameter comes back as "undefined" in some cases when running on Ubuntu.  It also comes back as EPIPE, which is often a signal that the socket connection is no longer there.  In any case, the error.exitCode parameter does always seem to be correct.

I've run this using the gatsby setup on my project with a range of jpg and png images, using a variety of quality values.  All appear to work with the change.

Changed this code (literally just error.code to error.exitCode):

```
	const promise = subprocess
		.then(result => result.stdout) // eslint-disable-line promise/prefer-await-to-then
		.catch(error => {
			if (error.code === 99) {
				return input;
			}

			error.message = error.stderr || error.message;
			throw error;
		});

```
To this:

```
	const promise = subprocess
		.then(result => result.stdout) // eslint-disable-line promise/prefer-await-to-then
		.catch(error => {
			if (error.exitCode === 99) {
				return input;
			}

			error.message = error.stderr || error.message;
			throw error;
		});


```
I also changed the package version to 9.0.1 on logic that it is a non-breaking minor change.