### PR TITLE
Fix the `strip` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 node_modules
 yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.idea
 node_modules
 yarn.lock

--- a/index.js
+++ b/index.js
@@ -25,7 +25,10 @@ const imageminPngquant = (options = {}) => input => {
 
 	if (typeof options.strip !== 'undefined') {
 		ow(options.strip, ow.boolean);
-		args.push('--strip');
+
+		if (options.strip) {
+			args.push('--strip');
+		}
 	}
 
 	if (typeof options.quality !== 'undefined') {


### PR DESCRIPTION
The strip option was not properly working. As soon as someone passed a boolean value (true or false) the strip option got included regardless of the actual value e.g false.