### PR TITLE
Standardize TypeScript exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,58 +1,57 @@
-export interface Options { // eslint-disable-line @typescript-eslint/consistent-type-definitions
+declare namespace pngquant {
+	type Options = {
+		/**
+	 	 * Speed `10` has 5% lower quality, but is about 8 times faster than the default. Speed `11` disables dithering and lowers compression level.
+		 * Values: `1` (brute-force) to `11` (fastest)
+		 * @default 3
+		 */
+		speed?: number;
+
+		/**
+	 	 * Remove optional metadata.
+		 * @default false
+		 */
+		strip?: boolean;
+
+		/**
+	 	 * Instructs pngquant to use the least amount of colors required to meet or exceed the max quality. If conversion results in quality below the min quality the image won't be saved.
+		 * Min and max are numbers in range 0 (worst) to 1 (perfect), similar to JPEG.
+		 * Values: `[0...1, 0...1]`
+		 * @example [0.3, 0.5]
+		 */
+		quality?: [number, number];
+
+		/**
+	 	 * Set the dithering level using a fractional number between 0 (none) and 1 (full).
+		 * Pass in `false` to disable dithering.
+		 * Values: 0...1
+		 * @default 1
+		 */
+		dithering?: number | boolean;
+
+		/**
+	 	 * Truncate number of least significant bits of color (per channel).
+		 * Use this when image will be output on low-depth displays (e.g. 16-bit RGB). pngquant will make almost-opaque pixels fully opaque and will reduce amount of semi-transparent colors.
+		 */
+		posterize?: number;
+
+		/**
+		 * Print verbose status messages.
+		 * @default false
+		 */
+		verbose?: boolean;
+	};
+
 	/**
-	Speed `10` has 5% lower quality, but is about 8 times faster than the default. Speed `11` disables dithering and lowers compression level.
-
-	Values: `1` (brute-force) to `11` (fastest)
-
-	@default 3
-	*/
-	speed?: number;
+	 * Buffer or stream to optimize.
+	 */
+	type Plugin = (input: Uint8Array | NodeJS.ReadableStream) => Promise<Uint8Array>;
 
 	/**
-	Remove optional metadata.
-
-	@default false
-	*/
-	strip?: boolean;
-
-	/**
-	Instructs pngquant to use the least amount of colors required to meet or exceed the max quality. If conversion results in quality below the min quality the image won't be saved.
-
-	Min and max are numbers in range 0 (worst) to 1 (perfect), similar to JPEG.
-
-	Values: `[0...1, 0...1]`
-
-	@example [0.3, 0.5]
-	*/
-	quality?: [number, number];
-
-	/**
-	Set the dithering level using a fractional number between 0 (none) and 1 (full).
-
-	Pass in `false` to disable dithering.
-
-	Values: 0...1
-
-	@default 1
-	*/
-	dithering?: number | boolean;
-
-	/**
-	Truncate number of least significant bits of color (per channel).
-
-	Use this when image will be output on low-depth displays (e.g. 16-bit RGB). pngquant will make almost-opaque pixels fully opaque and will reduce amount of semi-transparent colors.
-	*/
-	posterize?: number;
+	 * Imagemin plugin for pngquant.
+	 * @returns An Imagemin plugin.
+	 */
+	function imageminPngquant(options?: Options): Plugin;
 }
 
-/**
-Image data to optimize.
-*/
-export type Plugin = (input: Uint8Array) => Promise<Uint8Array>;
-
-/**
-Imagemin plugin for pngquant.
-
-@returns An Imagemin plugin.
-*/
-export default function imageminPngquant(options?: Options): Plugin;
+export = pngquant;

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,4 +53,4 @@ type Plugin = (input: Buffer | NodeJS.ReadableStream) => Promise<Buffer>;
  */
 declare function imageminPngquant(options?: Options): Plugin;
 
-export { type Options, type Plugin, imageminPngquant };
+export {type Options, type Plugin, imageminPngquant};

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,9 @@ type Options = {
 
 /**
  * Buffer or stream to optimize.
- * @todo Replace banned type Buffer with Uint8Array (@typescript-eslint/ban-types - https://sindresorhus.com/blog/goodbye-nodejs-buffer)
+ * @info Banned type Buffer has been replaced in Imagemin >=8.0.1 with Uint8Array, must stick to it.
+ * @see https://sindresorhus.com/blog/goodbye-nodejs-buffer [@typescript-eslint/ban-types]
+ * @see https://github.com/imagemin/imagemin/compare/v8.0.1...main
  */
 type Plugin = (input: Buffer | NodeJS.ReadableStream) => Promise<Buffer>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ type Options = {
  * @see https://sindresorhus.com/blog/goodbye-nodejs-buffer [@typescript-eslint/ban-types]
  * @see https://github.com/imagemin/imagemin/compare/v8.0.1...main
  */
-type Plugin = (input: Buffer | NodeJS.ReadableStream) => Promise<Buffer>;
+type Plugin = (input: Uint8Array | NodeJS.ReadableStream) => Promise<Uint8Array>;
 
 /**
  * Imagemin plugin for pngquant.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,57 +1,56 @@
-declare namespace pngquant {
-	type Options = {
-		/**
-	 	 * Speed `10` has 5% lower quality, but is about 8 times faster than the default. Speed `11` disables dithering and lowers compression level.
-		 * Values: `1` (brute-force) to `11` (fastest)
-		 * @default 3
-		 */
-		speed?: number;
-
-		/**
-	 	 * Remove optional metadata.
-		 * @default false
-		 */
-		strip?: boolean;
-
-		/**
-	 	 * Instructs pngquant to use the least amount of colors required to meet or exceed the max quality. If conversion results in quality below the min quality the image won't be saved.
-		 * Min and max are numbers in range 0 (worst) to 1 (perfect), similar to JPEG.
-		 * Values: `[0...1, 0...1]`
-		 * @example [0.3, 0.5]
-		 */
-		quality?: [number, number];
-
-		/**
-	 	 * Set the dithering level using a fractional number between 0 (none) and 1 (full).
-		 * Pass in `false` to disable dithering.
-		 * Values: 0...1
-		 * @default 1
-		 */
-		dithering?: number | boolean;
-
-		/**
-	 	 * Truncate number of least significant bits of color (per channel).
-		 * Use this when image will be output on low-depth displays (e.g. 16-bit RGB). pngquant will make almost-opaque pixels fully opaque and will reduce amount of semi-transparent colors.
-		 */
-		posterize?: number;
-
-		/**
-		 * Print verbose status messages.
-		 * @default false
-		 */
-		verbose?: boolean;
-	};
+type Options = {
+	/**
+	 * Speed `10` has 5% lower quality, but is about 8 times faster than the default. Speed `11` disables dithering and lowers compression level.
+	 * Values: `1` (brute-force) to `11` (fastest)
+	 * @default 3
+	 */
+	speed?: number;
 
 	/**
-	 * Buffer or stream to optimize.
+	 * Remove optional metadata.
+	 * @default false
 	 */
-	type Plugin = (input: Uint8Array | NodeJS.ReadableStream) => Promise<Uint8Array>;
+	strip?: boolean;
 
 	/**
-	 * Imagemin plugin for pngquant.
-	 * @returns An Imagemin plugin.
+	 * Instructs pngquant to use the least amount of colors required to meet or exceed the max quality. If conversion results in quality below the min quality the image won't be saved.
+	 * Min and max are numbers in range 0 (worst) to 1 (perfect), similar to JPEG.
+	 * Values: `[0...1, 0...1]`
+	 * @example [0.3, 0.5]
 	 */
-	function imageminPngquant(options?: Options): Plugin;
-}
+	quality?: [number, number];
 
-export = pngquant;
+	/**
+	 * Set the dithering level using a fractional number between 0 (none) and 1 (full).
+	 * Pass in `false` to disable dithering.
+	 * Values: 0...1
+	 * @default 1
+	 */
+	dithering?: number | boolean;
+
+	/**
+	 * Truncate number of least significant bits of color (per channel).
+	 * Use this when image will be output on low-depth displays (e.g. 16-bit RGB). pngquant will make almost-opaque pixels fully opaque and will reduce amount of semi-transparent colors.
+	 */
+	posterize?: number;
+
+	/**
+	 * Print verbose status messages.
+	 * @default false
+	 */
+	verbose?: boolean;
+};
+
+/**
+ * Buffer or stream to optimize.
+ * @todo Replace banned type Buffer with Uint8Array (@typescript-eslint/ban-types - https://sindresorhus.com/blog/goodbye-nodejs-buffer)
+ */
+type Plugin = (input: Buffer | NodeJS.ReadableStream) => Promise<Buffer>;
+
+/**
+ * Imagemin plugin for pngquant.
+ * @returns An Imagemin plugin.
+ */
+declare function imageminPngquant(options?: Options): Plugin;
+
+export { type Options, type Plugin, imageminPngquant };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
 		"pngquant-bin": "^9.0.0",
 		"uint8array-extras": "^1.1.0"
 	},
+	"peerDependencies": {
+		"imagemin": "^8.0.1"
+	},
 	"devDependencies": {
 		"@types/node": "^20.12.10",
 		"ava": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "imagemin-pngquant",
-	"version": "10.0.0",
+	"version": "11.0.0",
 	"description": "Imagemin plugin for `pngquant`",
 	"license": "MIT",
 	"repository": "imagemin/imagemin-pngquant",

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,7 @@ npm install imagemin-pngquant
 
 ### Prerequisites
 
-> **Linux** machines must have the following packages prior to install: `libpng-dev libimagequant-dev`  
+> **Linux** machines must have the following packages prior to install: `libpng-dev libimagequant-dev`
 
 ```sh
 sudo apt-get -y install libpng-dev libimagequant-dev
@@ -20,7 +20,7 @@ sudo apt-get -y install libpng-dev libimagequant-dev
 
 ```js
 import imagemin from 'imagemin';
-import imageminPngquant from 'imagemin-pngquant';
+import { imageminPngquant } from 'imagemin-pngquant';
 
 await imagemin(['images/*.png'], {
 	destination: 'build/images',


### PR DESCRIPTION
Fixes TS(2349) when using this basic example:

```
import imagemin from 'imagemin'
import imageminPngquant from 'imagemin-pngquant'

const compressed = await imagemin.buffer(Buffer.from(body), {
  plugins: [
    imageminJpegtran(),
    imageminPngquant({
      quality: [0.6, 0.8]
    })
  ]
})
```


Breaking, requires bump to 11.0.0. 